### PR TITLE
Add action: Replace String in Response Value

### DIFF
--- a/background.js
+++ b/background.js
@@ -288,6 +288,31 @@ function rewriteResponseHeader(e) {
           if (config.debug_mode) log("cookie_delete.resp delete_header : name=" + to_modify.header_name + " for url " + e.url);
         }
       }
+      else if (to_modify.action === "replace_value") {
+        for (let header of e.responseHeaders) {
+          if (header.name.toLowerCase() === to_modify.header_name.toLowerCase()) {
+      			let replacePattern = to_modify.header_value;
+      			let originalValue = header.value;
+      
+      			let match = replacePattern.match(/\((.*?)\)\((.*?)\)/);
+      			let searchString = match[1]; // What to search for in the original value
+      			let replaceString = match[2]; // What to replace with in the original value, to create the new value
+      
+      			let regex = new RegExp(searchString, "g");
+      			let newValue = originalValue.replace(regex, replaceString);			
+      			
+      			if (config.debug_mode) log(
+              "Replace value in response header :  name= " + to_modify.header_name +
+              ",old value=" + originalValue + 
+              ",replace pattern=" + replacePattern +
+              ",new value=" + newValue + 
+              " for url " + e.url
+            );	
+            
+      			header.value = newValue; 			  
+          }
+        }
+      }
     }
   }
   if (config.debug_mode) log("End modify response headers for url " + e.url);

--- a/popup/config.js
+++ b/popup/config.js
@@ -126,6 +126,7 @@ function appendLine(url_contains,action,header_name,header_value,comment,apply_o
         <option value="delete">Delete</option>
         <option value="cookie_add_or_modify">Cookie Add/Modify</option>
         <option value="cookie_delete">Cookie Delete</option>
+	<option value="replace_value">Replace String In Response Value</option>
       </select>
     </td>
     <td>


### PR DESCRIPTION
With these changes I add the option to replace a string in the value of a response header.

One can select this action in the table of the config menu. Under the header field value you then provide a pattern like so: (text to search for)(text to replace with). For example (apple)(boat) will replace 'apple' with 'boat' in the value of the response header.

I was looking for this feature since I needed to change the Content-Security-Policy of a page. However, the Content-Security-Policy was dynamically crafted with nonces. I did not want to delete the entire CSP; I wanted a CSP with these nonces still in there. As a regular modify (always to one certain, pre-specified value) could not achieve this, I needed a string replace option.

Hereby I share that feature. If it gets accepted to the master branch, the README.md would still have to be updated to explain this feature.